### PR TITLE
correct latest tag override behavior

### DIFF
--- a/abaco-deploy.sh
+++ b/abaco-deploy.sh
@@ -286,7 +286,7 @@ if [ ! -z "${passed_image_tag}" ]; then
   DOCKER_IMAGE_VERSION=${passed_image_tag}
 fi
 # Force image to have a :version
-if [ ! -z "${DOCKER_IMAGE_VERSION}" ]; then
+if [ -z "${DOCKER_IMAGE_VERSION}" ]; then
   DOCKER_IMAGE_VERSION="latest"
   echo "Defaulting to ${DOCKER_IMAGE_TAG}:latest"
 fi


### PR DESCRIPTION
On abaco deploy, the user is expected to be able to provide a tag with the -t flag that will be used as the docker image version. This is passed in and set correctly in abaco-deploy.sh as `DOCKER_IMAGE_VERSION`.

However, `DOCKER_IMAGE_VERSION` is overwritten to latest because of a ! on the null string check. Removing the ! corrects the behavior to only set the version to 'latest' if `DOCKER_IMAGE_VERSION` IS a null string.